### PR TITLE
Refactor 4: move plugin state out of core storage

### DIFF
--- a/packages/app/src/BasicColorPicker.tsx
+++ b/packages/app/src/BasicColorPicker.tsx
@@ -6,14 +6,14 @@ import { CanvasStore } from "./xqcanvas/CanvasInterfaces";
 
 export const BasicColorPicker = (props: { canvas: CanvasStore; currentPaletteItem: number }) => {
 
-  const setCurrPaletteItemColor = (color: string) => {
+  const setCurrentPaletteItemColor = (color: string) => {
     props.canvas.setPaletteItem(props.currentPaletteItem, color);
   };
 
   return (
     <HexColorPicker
       color={props.canvas.getPaletteItemColor(props.currentPaletteItem)}
-      onChange={setCurrPaletteItemColor}
+      onChange={setCurrentPaletteItemColor}
     />
   );
 };

--- a/packages/app/src/BasicColorPicker.tsx
+++ b/packages/app/src/BasicColorPicker.tsx
@@ -3,16 +3,16 @@ import { HexColorPicker } from "react-colorful";
 import { CanvasSkin } from "./CanvasSkin";
 import { CanvasStore } from "./xqcanvas/CanvasInterfaces";
 
-export const BasicColorPicker = (props: { canvas: CanvasStore }) => {
-  const canvas = props.canvas;
+
+export const BasicColorPicker = (props: { canvas: CanvasStore; currentPaletteItem: number }) => {
 
   const setCurrPaletteItemColor = (color: string) => {
-    canvas.setPaletteItem(canvas.currPaletteItem, color);
+    props.canvas.setPaletteItem(props.currentPaletteItem, color);
   };
 
   return (
     <HexColorPicker
-      color={canvas.getPaletteItemColor(canvas.currPaletteItem)}
+      color={props.canvas.getPaletteItemColor(props.currentPaletteItem)}
       onChange={setCurrPaletteItemColor}
     />
   );

--- a/packages/app/src/BasicPalette.tsx
+++ b/packages/app/src/BasicPalette.tsx
@@ -17,7 +17,7 @@ export const BasicPalette = (props: { canvas: CanvasStore; controls: CanvasPalet
   const didClickRemovePaletteItem = () => {
     if (canvas.paletteSize > 2) {
       canvas.setPaletteSize(canvas.paletteSize - 1);
-      if (canvas.currPaletteItem >= canvas.paletteSize - 1) {
+      if (props.controls.currentItem >= canvas.paletteSize - 1) {
         props.controls.setCurrentItem(canvas.paletteSize - 2);
       }
     }
@@ -36,7 +36,7 @@ export const BasicPalette = (props: { canvas: CanvasStore; controls: CanvasPalet
         key={itemKey}
         className={itemClasses}
         style={{ backgroundColor: itemColor }}
-        onClick={(event) => controls.setCurrentItem(pi)}
+        onClick={(event) => props.controls.setCurrentItem(pi)}
       >
         <input
           className="p-2 w-24"

--- a/packages/app/src/BasicPalette.tsx
+++ b/packages/app/src/BasicPalette.tsx
@@ -8,18 +8,17 @@ import { CanvasPaletteControls } from "/.usePaletteControls";
 
 export const BasicPalette = (props: { canvas: CanvasStore; controls: CanvasPaletteControls }) => {
   const canvas = props.canvas;
-  const controls = props.controls;
 
   const didClickAddPaletteItem = () => {
     canvas.setPaletteSize(canvas.paletteSize + 1);
-    controls.setCurrentItem(canvas.paletteSize);
+    props.controls.setCurrentItem(canvas.paletteSize);
   };
 
   const didClickRemovePaletteItem = () => {
     if (canvas.paletteSize > 2) {
       canvas.setPaletteSize(canvas.paletteSize - 1);
       if (canvas.currPaletteItem >= canvas.paletteSize - 1) {
-        controls.setCurrentItem(canvas.paletteSize - 2);
+        props.controls.setCurrentItem(canvas.paletteSize - 2);
       }
     }
   };
@@ -29,7 +28,7 @@ export const BasicPalette = (props: { canvas: CanvasStore; controls: CanvasPalet
     const itemKey = paletteKey(pi);
     const itemColor = canvas.getPaletteItemColor(pi);
     const borderText =
-    controls.currentItem == pi ? "border-indigo-300" : "border-slate-800";
+    props.controls.currentItem == pi ? "border-indigo-300" : "border-slate-800";
     const itemClasses = `relative mx-1 sm:mx-4 my-2 p-1 sm:p-4 border-8 ${borderText}`;
     const label = pi > 0 ? `Color ${pi}` : `Background`;
     PaletteItems.push(

--- a/packages/app/src/BasicPalette.tsx
+++ b/packages/app/src/BasicPalette.tsx
@@ -4,20 +4,22 @@ import {
   paletteItemCollection,
   paletteKey,
 } from "./xqcanvas/CanvasInterfaces";
+import { CanvasPaletteControls } from "/.usePaletteControls";
 
-export const BasicPalette = (props: { canvas: CanvasStore }) => {
+export const BasicPalette = (props: { canvas: CanvasStore; controls: CanvasPaletteControls }) => {
   const canvas = props.canvas;
+  const controls = props.controls;
 
   const didClickAddPaletteItem = () => {
     canvas.setPaletteSize(canvas.paletteSize + 1);
-    canvas.setCurrPaletteItem(canvas.paletteSize);
+    controls.setCurrentItem(canvas.paletteSize);
   };
 
   const didClickRemovePaletteItem = () => {
     if (canvas.paletteSize > 2) {
       canvas.setPaletteSize(canvas.paletteSize - 1);
       if (canvas.currPaletteItem >= canvas.paletteSize - 1) {
-        canvas.setCurrPaletteItem(canvas.paletteSize - 2);
+        controls.setCurrentItem(canvas.paletteSize - 2);
       }
     }
   };
@@ -27,7 +29,7 @@ export const BasicPalette = (props: { canvas: CanvasStore }) => {
     const itemKey = paletteKey(pi);
     const itemColor = canvas.getPaletteItemColor(pi);
     const borderText =
-      canvas.currPaletteItem == pi ? "border-indigo-300" : "border-slate-800";
+    controls.currentItem == pi ? "border-indigo-300" : "border-slate-800";
     const itemClasses = `relative mx-1 sm:mx-4 my-2 p-1 sm:p-4 border-8 ${borderText}`;
     const label = pi > 0 ? `Color ${pi}` : `Background`;
     PaletteItems.push(
@@ -35,7 +37,7 @@ export const BasicPalette = (props: { canvas: CanvasStore }) => {
         key={itemKey}
         className={itemClasses}
         style={{ backgroundColor: itemColor }}
-        onClick={(event) => canvas.setCurrPaletteItem(pi)}
+        onClick={(event) => controls.setCurrentItem(pi)}
       >
         <input
           className="p-2 w-24"

--- a/packages/app/src/DemoCanvas.tsx
+++ b/packages/app/src/DemoCanvas.tsx
@@ -109,7 +109,7 @@ export const DemoCanvas = () => {
       </div>
 
       <div className="my-6 mx-24">
-        <BasicColorPicker canvas={DemoCanvasStore}></BasicColorPicker>
+        <BasicColorPicker canvas={DemoCanvasStore} currentPaletteItem={DemoPaletteControlStore.currentItem}></BasicColorPicker>
       </div>
     </div>
   );

--- a/packages/app/src/DemoCanvas.tsx
+++ b/packages/app/src/DemoCanvas.tsx
@@ -3,7 +3,7 @@ import { BasicPalette } from "./BasicPalette";
 import { CanvasLogo } from "./CanvasLogo";
 import { usePaletteControls } from "./usePaletteControls";
 import { CanvasSkin } from "./CanvasSkin";
-import { EyeDropper } from "./EyeDropper";
+import { EyeDropper, useEyeDropperStore } from "./EyeDropper";
 import { LoadFile } from "./LoadFile";
 import { MoveImage } from "./MoveImage";
 import { SaveFile } from "./SaveFile";
@@ -14,13 +14,14 @@ export const DemoCanvas = () => {
   // core canvas state
   const DemoCanvasStore = useXqstCanvasStore();
   const DemoPaletteControlStore = usePaletteControls();
+  const DemoDropperStore = useEyeDropperStore();
 
   const didClickPixel = (x: number, y: number) => {
-    if (!DemoCanvasStore.dropperActive) {
+    if (!DemoDropperStore.active) {
       DemoCanvasStore.setPixel(x, y, DemoPaletteControlStore.currentItem);
     } else {
-      DemoCanvasStore.setPaletteItem(DemoPaletteControlStore.currentItem, DemoCanvasStore.getPixelVal(x, y));
-      DemoCanvasStore.setDropperActive(false);
+      DemoPaletteControlStore.setCurrentItem(DemoCanvasStore.getPixelVal(x, y));
+      DemoDropperStore.setActive(false);
     }
   };
 
@@ -81,7 +82,7 @@ export const DemoCanvas = () => {
           />
         </fieldset>
         <div className="bg-white mt-2 mx-2">
-          <EyeDropper canvas={DemoCanvasStore}></EyeDropper>
+          <EyeDropper canvas={DemoCanvasStore} dropperStore={DemoDropperStore}></EyeDropper>
         </div>
         <div className="bg-white mt-2 mx-2">
           <MoveImage canvas={DemoCanvasStore} direction="up"></MoveImage>

--- a/packages/app/src/DemoCanvas.tsx
+++ b/packages/app/src/DemoCanvas.tsx
@@ -1,6 +1,7 @@
 import { BasicColorPicker } from "./BasicColorPicker";
 import { BasicPalette } from "./BasicPalette";
 import { CanvasLogo } from "./CanvasLogo";
+import { usePaletteControls } from "./usePaletteControls";
 import { CanvasSkin } from "./CanvasSkin";
 import { EyeDropper } from "./EyeDropper";
 import { LoadFile } from "./LoadFile";
@@ -12,12 +13,13 @@ import { XqstCanvasDisplay } from "./xqcanvas/XqstCanvasDisplay";
 export const DemoCanvas = () => {
   // core canvas state
   const DemoCanvasStore = useXqstCanvasStore();
+  const DemoPaletteControlStore = usePaletteControls();
 
   const didClickPixel = (x: number, y: number) => {
     if (!DemoCanvasStore.dropperActive) {
-      DemoCanvasStore.setPixel(x, y, DemoCanvasStore.currPaletteItem);
+      DemoCanvasStore.setPixel(x, y, DemoPaletteControlStore.currentItem);
     } else {
-      DemoCanvasStore.setCurrPaletteItem(DemoCanvasStore.getPixelVal(x, y));
+      DemoCanvasStore.setPaletteItem(DemoPaletteControlStore.currentItem, DemoCanvasStore.getPixelVal(x, y));
       DemoCanvasStore.setDropperActive(false);
     }
   };
@@ -103,7 +105,7 @@ export const DemoCanvas = () => {
       </div>
 
       <div className="mt-2">
-        <BasicPalette canvas={DemoCanvasStore}></BasicPalette>
+        <BasicPalette canvas={DemoCanvasStore} controls={DemoPaletteControlStore}></BasicPalette>
       </div>
 
       <div className="my-6 mx-24">

--- a/packages/app/src/DemoCanvas.tsx
+++ b/packages/app/src/DemoCanvas.tsx
@@ -11,14 +11,14 @@ import { XqstCanvasDisplay } from "./xqcanvas/XqstCanvasDisplay";
 
 export const DemoCanvas = () => {
   // core canvas state
-  const XqstStore = useXqstCanvasStore();
+  const DemoCanvasStore = useXqstCanvasStore();
 
   const didClickPixel = (x: number, y: number) => {
-    if (!XqstStore.dropperActive) {
-      XqstStore.setPixel(x, y, XqstStore.currPaletteItem);
+    if (!DemoCanvasStore.dropperActive) {
+      DemoCanvasStore.setPixel(x, y, DemoCanvasStore.currPaletteItem);
     } else {
-      XqstStore.setCurrPaletteItem(XqstStore.getPixelVal(x, y));
-      XqstStore.setDropperActive(false);
+      DemoCanvasStore.setCurrPaletteItem(DemoCanvasStore.getPixelVal(x, y));
+      DemoCanvasStore.setDropperActive(false);
     }
   };
 
@@ -28,20 +28,20 @@ export const DemoCanvas = () => {
         <div className="ml-6 my-2 w-20 sm:w-28">
           <CanvasLogo></CanvasLogo>
         </div>
-        <LoadFile canvas={XqstStore}></LoadFile>
-        <SaveFile canvas={XqstStore} format="binary"></SaveFile>
-        <SaveFile canvas={XqstStore} format="hex"></SaveFile>
-        <SaveFile canvas={XqstStore} format="svg"></SaveFile>
+        <LoadFile canvas={DemoCanvasStore}></LoadFile>
+        <SaveFile canvas={DemoCanvasStore} format="binary"></SaveFile>
+        <SaveFile canvas={DemoCanvasStore} format="hex"></SaveFile>
+        <SaveFile canvas={DemoCanvasStore} format="svg"></SaveFile>
         <div className="flex flex-column items-center my-2 ml-4 sm:ml-12">
           <div className="bg-slate-600 py-2 px-2 sm:px-4 h-10">
             <input
               type="range"
               min="10"
               max="400"
-              value={XqstStore.zoom}
+              value={DemoCanvasStore.zoom}
               onChange={(event) => {
                 if (event.target) {
-                  XqstStore.setZoom(parseInt(event.target.value));
+                  DemoCanvasStore.setZoom(parseInt(event.target.value));
                 }
               }}
             />
@@ -56,10 +56,10 @@ export const DemoCanvas = () => {
             className="w-16 px-2 h-8"
             type="number"
             name="WIDTH"
-            value={XqstStore.width}
+            value={DemoCanvasStore.width}
             onChange={(event) => {
               if (event.target) {
-                XqstStore.setWidth(parseInt(event.target.value));
+                DemoCanvasStore.setWidth(parseInt(event.target.value));
               }
             }}
           />
@@ -70,44 +70,44 @@ export const DemoCanvas = () => {
             className="w-16 px-2 h-8"
             type="number"
             name="HEIGHT"
-            value={XqstStore.height}
+            value={DemoCanvasStore.height}
             onChange={(event) => {
               if (event.target) {
-                XqstStore.setHeight(parseInt(event.target.value));
+                DemoCanvasStore.setHeight(parseInt(event.target.value));
               }
             }}
           />
         </fieldset>
         <div className="bg-white mt-2 mx-2">
-          <EyeDropper canvas={XqstStore}></EyeDropper>
+          <EyeDropper canvas={DemoCanvasStore}></EyeDropper>
         </div>
         <div className="bg-white mt-2 mx-2">
-          <MoveImage canvas={XqstStore} direction="up"></MoveImage>
+          <MoveImage canvas={DemoCanvasStore} direction="up"></MoveImage>
         </div>
         <div className="bg-white mt-2 mx-2">
-          <MoveImage canvas={XqstStore} direction="down"></MoveImage>
+          <MoveImage canvas={DemoCanvasStore} direction="down"></MoveImage>
         </div>
         <div className="bg-white mt-2 mx-2">
-          <MoveImage canvas={XqstStore} direction="left"></MoveImage>
+          <MoveImage canvas={DemoCanvasStore} direction="left"></MoveImage>
         </div>
         <div className="bg-white mt-2 mx-2">
-          <MoveImage canvas={XqstStore} direction="right"></MoveImage>
+          <MoveImage canvas={DemoCanvasStore} direction="right"></MoveImage>
         </div>
       </div>
 
       <div className="mt-6">
         <XqstCanvasDisplay
-          canvas={XqstStore}
+          canvas={DemoCanvasStore}
           didClickPixel={didClickPixel}
         ></XqstCanvasDisplay>
       </div>
 
       <div className="mt-2">
-        <BasicPalette canvas={XqstStore}></BasicPalette>
+        <BasicPalette canvas={DemoCanvasStore}></BasicPalette>
       </div>
 
       <div className="my-6 mx-24">
-        <BasicColorPicker canvas={XqstStore}></BasicColorPicker>
+        <BasicColorPicker canvas={DemoCanvasStore}></BasicColorPicker>
       </div>
     </div>
   );

--- a/packages/app/src/EyeDropper.tsx
+++ b/packages/app/src/EyeDropper.tsx
@@ -1,18 +1,34 @@
 import { CanvasSkin } from "./CanvasSkin";
 import { CanvasStore } from "./xqcanvas/CanvasInterfaces";
+import { useState } from 'react';
 
-export const EyeDropper = (props: { canvas: CanvasStore }) => {
-  const canvas = props.canvas;
+export const EyeDropper = (props: { canvas: CanvasStore, dropperStore: EyeDropperStore }) => {
 
-  const didClickDropper = () => {
-    canvas.setDropperActive(!canvas.dropperActive);
-  };
+  function didClickDropper() {
+    props.dropperStore.setActive(!props.dropperStore.active);
+  }
 
   return (
     <button onClick={didClickDropper} className="pt-1 px-1">
       <CanvasSkin
-        item={canvas.dropperActive ? "dropper-active" : "dropper"}
+        item={props.dropperStore.active ? "dropper-active" : "dropper"}
       ></CanvasSkin>
     </button>
   );
+};
+
+export interface EyeDropperStore {
+  active: boolean;
+  setActive: (val: boolean) => void;
+};
+
+export function useEyeDropperStore(): EyeDropperStore {
+  const [active, setActive] = useState(false);
+  const dropStore : EyeDropperStore = {
+      active,
+      setActive: (var: boolean) => {
+        setActive(var);
+      }
+  };
+  return dropStore;
 };

--- a/packages/app/src/usePaletteControls.ts
+++ b/packages/app/src/usePaletteControls.ts
@@ -6,7 +6,7 @@ export interface CanvasPaletteControls {
 }
 
 export function usePaletteControls(): CanvasPaletteControls {
-    const [currItem, setCurrItem] = useState(0);
+    const [currItem, setCurrItem] = useState(1);
     const controls : CanvasPaletteControls = {
         currentItem: currItem,
         setCurrentItem: (var: number) => {

--- a/packages/app/src/usePaletteControls.ts
+++ b/packages/app/src/usePaletteControls.ts
@@ -1,0 +1,17 @@
+import { useState } from 'react';
+
+export interface CanvasPaletteControls {
+    currentItem: number;
+    setCurrentItem: (val: number) => void;
+}
+
+export function usePaletteControls(): CanvasPaletteControls {
+    const [currItem, setCurrItem] = useState(0);
+    const controls : CanvasPaletteControls = {
+        currentItem: currItem,
+        setCurrentItem: (var: number) => {
+            setCurrItem(var);
+        },
+    };
+    return controls;
+}

--- a/packages/app/src/xqcanvas/CanvasInterfaces.ts
+++ b/packages/app/src/xqcanvas/CanvasInterfaces.ts
@@ -40,8 +40,6 @@ export interface CanvasCoreStore {
   setPixels: (vals: pixelCanvas) => void;
 
   // the following are UI state and would be better in their own stores
-  currPaletteItem: number;
-  setCurrPaletteItem: (val: number) => void;
   dropperActive: boolean;
   setDropperActive: (val: boolean) => void;
 }

--- a/packages/app/src/xqcanvas/CanvasInterfaces.ts
+++ b/packages/app/src/xqcanvas/CanvasInterfaces.ts
@@ -38,10 +38,6 @@ export interface CanvasCoreStore {
   pixels: pixelCanvas;
   setPixel: (x: number, y: number, val: number) => void;
   setPixels: (vals: pixelCanvas) => void;
-
-  // the following are UI state and would be better in their own stores
-  dropperActive: boolean;
-  setDropperActive: (val: boolean) => void;
 }
 
 export interface CanvasStore extends CanvasCoreStore {

--- a/packages/app/src/xqcanvas/XqstCanvasDisplay.tsx
+++ b/packages/app/src/xqcanvas/XqstCanvasDisplay.tsx
@@ -102,7 +102,7 @@ export const XqstCanvasDisplay = (props: {
   }, [
     width,
     height,
-    currPaletteItem,
+    props.didClickPixel,
     dropperActive,
     paletteSize,
     paletteString,

--- a/packages/app/src/xqcanvas/XqstCanvasDisplay.tsx
+++ b/packages/app/src/xqcanvas/XqstCanvasDisplay.tsx
@@ -20,7 +20,6 @@ export const XqstCanvasDisplay = (props: {
   const zoom = canvas.zoom;
   const paletteSize = canvas.paletteSize;
   const paletteString = canvas.getPaletteItemColorsStr();
-  const dropperActive = canvas.dropperActive;
   const svgCanvasRef = useRef<SVGSVGElement | null>(null);
   const lastPixelDownRef = useRef<boolean | null>(null);
 
@@ -102,7 +101,6 @@ export const XqstCanvasDisplay = (props: {
     width,
     height,
     props.didClickPixel,
-    dropperActive,
     paletteSize,
     paletteString,
   ]);

--- a/packages/app/src/xqcanvas/XqstCanvasDisplay.tsx
+++ b/packages/app/src/xqcanvas/XqstCanvasDisplay.tsx
@@ -18,7 +18,6 @@ export const XqstCanvasDisplay = (props: {
   const width = canvas.width;
   const height = canvas.height;
   const zoom = canvas.zoom;
-  const currPaletteItem = canvas.currPaletteItem;
   const paletteSize = canvas.paletteSize;
   const paletteString = canvas.getPaletteItemColorsStr();
   const dropperActive = canvas.dropperActive;

--- a/packages/app/src/xqcanvas/useXqstCanvasStore.tsx
+++ b/packages/app/src/xqcanvas/useXqstCanvasStore.tsx
@@ -51,8 +51,6 @@ const useCanvasStore = create<CanvasCoreStore>((set) => ({
       return { pixels: newPixels };
     }),
   setPixels: (vals: pixelCanvas) => set((state) => ({ pixels: vals })),
-  dropperActive: false,
-  setDropperActive: (val: boolean) => set({ dropperActive: val }),
 }));
 
 export function useXqstCanvasStore(): CanvasStore {

--- a/packages/app/src/xqcanvas/useXqstCanvasStore.tsx
+++ b/packages/app/src/xqcanvas/useXqstCanvasStore.tsx
@@ -53,9 +53,6 @@ const useCanvasStore = create<CanvasCoreStore>((set) => ({
   setPixels: (vals: pixelCanvas) => set((state) => ({ pixels: vals })),
   dropperActive: false,
   setDropperActive: (val: boolean) => set({ dropperActive: val }),
-  currPaletteItem: 1,
-  setCurrPaletteItem: (val: number) =>
-    set((state) => ({ currPaletteItem: val })),
 }));
 
 export function useXqstCanvasStore(): CanvasStore {


### PR DESCRIPTION
It should be possible to use other storage when writing plugins, the ones to move out of the core storage are noted this PR is to move them out of the main CanvasStore since not all implementations will need them. 